### PR TITLE
Fix "main" and "types" field in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,8 @@
   "name": "typed-validation",
   "version": "0.8.2",
   "description": "Validate Objects Against TypeScript Interfaces",
-  "main": "dist/index.js",
-  "types": "dist/index.d.ts",
+  "main": "index.js",
+  "types": "index.d.ts",
   "scripts": {
     "build": "npm run clean && tsc --pretty --outDir ./dist/ || exit 0",
     "watch": "npm run clean && tsc --pretty -w --outDir ./dist/",


### PR DESCRIPTION
The files are output to the root directory, rather than `/dist`. On newer versions of Node, an incorrect path here results in a DEP0128 warning